### PR TITLE
Do not expose physical path when 404'ing

### DIFF
--- a/MethodHandlers/WebDAVMethodHandlerBase.cs
+++ b/MethodHandlers/WebDAVMethodHandlerBase.cs
@@ -112,10 +112,10 @@ namespace WebDAVSharp.Server.MethodHandlers
             }
             catch (WebDavNotFoundException wex)
             {
-                throw new WebDavNotFoundException(String.Format("Cannot found name {0} from uri {1} father {2}", name, childUri, collection.ItemPath), wex);
+                throw new WebDavNotFoundException(String.Format("Not found. Uri: {0}", childUri), wex);
             }
             if (item == null)
-                throw new WebDavNotFoundException(String.Format("Cannot found name {0} from uri {1} father {2}", name, childUri, collection.ItemPath));
+                throw new WebDavNotFoundException(String.Format("Not found. Uri: {0}", childUri));
 
             return item;
         }


### PR DESCRIPTION
This exception message exposes the physical `ItemPath` of the collection, which could be seen as a security risk.

(The 404 response body on localhost/test used to be:)

    Cannot found name test from uri http://localhost:8080/test father C:\Dev\WebDAV server test\

Instead, now it will be in the same style as `GetParentCollection`:

    Not found. Uri: http://localhost:8080/test